### PR TITLE
✏️ 반응형 -auth 헤더 모바일(모바일에서만 흰색헤더)

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,17 @@
+import AuthHeader from '@/components/layout/AuthHeader';
+import Header from '@/components/layout/Header';
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {/* ✅ 모바일에서는 흰색 AuthHeader.tsx, 데스크탑에서는 기존 Header.tsx 유지 */}
+      <div className="md:hidden">
+        <AuthHeader />
+      </div>
+      <div className="hidden md:block">
+        <Header />
+      </div>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/src/app/(auth)/sign-in/_components/FindIdModal.tsx
+++ b/src/app/(auth)/sign-in/_components/FindIdModal.tsx
@@ -82,11 +82,13 @@ const FindIdModal = ({ onClose }: { onClose: () => void }) => {
   return (
     <div className=" fixed inset-0 bg-black bg-opacity-50 flex sm:items-center items-start justify-center z-50 px-0 sm:px-4">
       <div className="w-full sm:max-w-[424px] min-h-screen sm:min-h-0 sm:h-auto bg-white sm:rounded-lg shadow-lg relative px-9 sm:px-9 sm:py-9 overflow-y-auto">
-        <p className=" sm:hidden flex flex-col justify-center items-center text-neutral-800 mt-[30px]">아이디 찾기</p>
-        <div className="flex flex-row justify-end ">
-          <button onClick={onClose} className="text-neutral-800 hover:text-black font-bold cursor-pointer">
-            <CloseButtonIcon />
-          </button>
+        <div>
+          <p className=" sm:hidden flex flex-col justify-center items-center text-neutral-800 mt-[30px]">아이디 찾기</p>
+          <div className="flex flex-row justify-end ">
+            <button onClick={onClose} className="text-neutral-800 hover:text-black font-bold cursor-pointer">
+              <CloseButtonIcon />
+            </button>
+          </div>
         </div>
 
         {form.modalType === 'input' && (

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import React, { useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
 import { login } from './actions/login';
 import Swal from 'sweetalert2';
 import DividerIcon from '@/components/ui/icon/DividerIcon';
@@ -9,6 +9,7 @@ import FindIdModal from './_components/FindIdModal';
 import FindPasswordModal from './_components/FindPasswordModal/FindPasswordModal';
 import KakaoSignIn from './_components/KakaoSignIn';
 import LogoAuth from '@/components/ui/icon/LogoAuth';
+import Header from '@/components/layout/Header';
 
 const SignInPage = () => {
   const [form, setForm] = useState({
@@ -19,7 +20,6 @@ const SignInPage = () => {
     isFindPasswordOpen: false
   });
   const router = useRouter();
-
   const handleSignUp = () => {
     router.push('/sign-up');
   };
@@ -67,14 +67,13 @@ const SignInPage = () => {
       });
     }
   };
-
   return (
     <>
       {form.isFindIdModalOpen && <FindIdModal onClose={() => setForm({ ...form, isFindIdModalOpen: false })} />}
       {form.isFindPasswordOpen && <FindPasswordModal onClose={() => setForm({ ...form, isFindPasswordOpen: false })} />}
       <div className="flex justify-center items-center min-h-screen px-4 sm:px-6 lg:px-8">
         <div className="w-full max-w-[400px] lg:h-auto">
-          <div className="flex justify-center mt-[140px]">
+          <div className="flex justify-center ">
             <LogoAuth className="w-[74px] h-[21px] sm:w-[139.947px] sm:h-[36.813px]" />
           </div>
 

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -30,7 +30,7 @@ const Page = () => {
   };
   return (
     <div className="flex flex-col justify-center items-center min-h-screen px-4 sm:px-6 lg:px-8">
-      <div className="flex justify-center mt-[60px] sm:mt-[80px]">
+      <div className="flex justify-center ">
         <LogoAuth className="w-[74px] h-[21px] sm:w-[139.947px] sm:h-[36.813px]" />
       </div>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,8 @@ import AuthProvider from './_provider/AuthProvider';
 import InquiryFloatingButton from '@/components/common/InquiryFloatingButton';
 
 import '../styles/globals.css';
+import { headers } from 'next/headers';
+import ClientWrapper from '@/components/layout/ClientWrapper';
 
 const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
@@ -48,7 +50,10 @@ const RootLayout = ({
       <AuthProvider>
         <MyProvider>
           <body className="font-pretendard">
-            <Header />
+            {/* /⭐설명: auth 모바일 헤더 달라서 ClientWrapper로 감싸주었습니다. */}
+            <ClientWrapper>
+              <Header />
+            </ClientWrapper>
             {children}
             <Footer />
             <InquiryFloatingButton />

--- a/src/components/layout/AuthHeader.tsx
+++ b/src/components/layout/AuthHeader.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { GoBackIcon } from '../ui/icon/GoBackIcon';
+// ⭐설명: auth에 쓰인 헤더ui
+export default function AuthHeader() {
+  const router = useRouter();
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+  return (
+    <div className="bg-white p-4">
+      <button onClick={handleBack}>
+        <GoBackIcon />
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/ClientWrapper.tsx
+++ b/src/components/layout/ClientWrapper.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function ClientWrapper({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const [isAuthPage, setIsAuthPage] = useState(false);
+  // ⭐설명: pathname가 sign-in,up 시작하면,
+  // isAuthPage를 true로 설정하고 auth에서 children(전역레이아웃) 렌더링을 막아주는 코드입니다.
+  useEffect(() => {
+    setIsAuthPage(pathname.startsWith('/sign-in') || pathname.startsWith('/sign-up'));
+  }, [pathname]);
+
+  return <>{!isAuthPage && children}</>;
+}

--- a/src/components/ui/icon/GoBackIcon.tsx
+++ b/src/components/ui/icon/GoBackIcon.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const GoBackIcon = () => {
+  return (
+    <div>
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 18L9 12L15 6" stroke="#444444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

pull 받고 올림 
데스크탑에서는 전역으로 뿌린 헤더가 보이지만
모바일에서는 흰색으로 보여야 함

usePathname를 써야하지만, 서버에서 먼저 렌더링되기 때문에 에러가 남
따라서 usePathname는 클라이언트 전용임 그래서 useEffect써서 해결하려고 했는데도 같은 에러발생.

그래서 그냥 전역 레이아웃에서 ClientWrapper로 Header를 감싸고 
ClientWrapper에서 경로를 설정해줌(주석으로 설명달아놓음)

auth안에 레이아웃 생성하여 최종적으로 해결함

`   <div className="md:hidden">
        <AuthHeader />
      </div>
      <div className="hidden md:block">
        <Header />
      </div>
      <main>{children}</main>
`

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).